### PR TITLE
Make Yoga lowercase in Podfile

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -63,7 +63,7 @@ target 'HelloWorld' do
   pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
   pod 'ReactCommon/jscallinvoker', :path => "../node_modules/react-native/ReactCommon"
   pod 'ReactCommon/turbomodule/core', :path => "../node_modules/react-native/ReactCommon"
-  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+  pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
 
   pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
   pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'


### PR DESCRIPTION
## Summary

When doing RN init from scratch for 0.61, I noticed pod install was failing. This was because "yoga" was mis-spelled to "Yoga" in the podfile. Thus, it couldn't find the podspec file.

```
[!] No podspec found for `Yoga` in `../node_modules/react-native/ReactCommon/yoga
```
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

iOS [Fixed] - Fix yoga case sensitivity in PodFile to match PodSpec
